### PR TITLE
Remove style for <a> element

### DIFF
--- a/src/routes/players_list/ui/player_row.module.css
+++ b/src/routes/players_list/ui/player_row.module.css
@@ -30,11 +30,11 @@
   text-align: start;
 }
 
-a {
+.link {
   color: black;
   text-decoration: none;
 }
 
-a:hover {
+.link:hover {
   color: var(--dark-pink);
 }

--- a/src/routes/players_list/ui/player_row.tsx
+++ b/src/routes/players_list/ui/player_row.tsx
@@ -34,7 +34,9 @@ export const PlayerRow = ({ player }: { player: PlayerStore }) => {
     <div key={player.key} className={styles.playerRow}>
       <div className={styles.playerName}>
         <Subheading>
-          <Link to={`../player/${player.key}`}>{player.playerName}</Link>
+          <Link to={`../player/${player.key}`} className={styles.link}>
+            {player.playerName}
+          </Link>
         </Subheading>
       </div>
       <div className={styles.details}>


### PR DESCRIPTION
**Issue**: The style for `<a>` element wasn't scoped to the module, but was global. 

**Patch**: Move the style for the `<a>` element to the `link` class.